### PR TITLE
Remove whitespace from hosts

### DIFF
--- a/provy/core/runner.py
+++ b/provy/core/runner.py
@@ -26,7 +26,7 @@ def run(provfile_path, server_name, password, extra_options):
                     server['options'][option_name] = value
 
     for server in servers:
-        host_string = "%s@%s" % (server['user'], server['address'])
+        host_string = "%s@%s" % (server['user'], server['address'].strip())
 
         context = {
             'abspath': dirname(abspath(provfile_path)),


### PR DESCRIPTION
To avoid copy and paste mistakes and to have consistent behavior with fabric.
