### PR TITLE
Fix is_package_installed method of YumRole

### DIFF
--- a/provy/more/centos/package/yum.py
+++ b/provy/more/centos/package/yum.py
@@ -220,7 +220,7 @@ class YumRole(Role):
         package = self.execute(
                 'rpm -qa %s' % package_name, stdout=False, sudo=True,
             )
-        return True if package else False
+        return bool(package)
 
     def ensure_package_installed(self, package_name):
         '''


### PR DESCRIPTION
The previous implementation could lead to not expected behavior.

Eg: role.is_package_installed('gcc') would match also to 'libgcc',
whereas 'libgcc' doesn't depend on gcc, the method would return True
even if gcc isn't installed.

The new implementation makes use of:
rpm -qa <package_name>

Which is a very strict match.
