### PR TITLE
Fix dependecy name

### DIFF
--- a/provy/more/centos/package/pip.py
+++ b/provy/more/centos/package/pip.py
@@ -47,7 +47,7 @@ class PipRole(Role):
         with self.using(YumRole) as role:
             role.ensure_up_to_date()
             role.ensure_package_installed('python-setuptools')
-            role.ensure_package_installed('python-dev')
+            role.ensure_package_installed('python-devel')
         self.execute("easy_install pip", sudo=True, stdout=False)
 
     def is_package_installed(self, package_name, version=None):


### PR DESCRIPTION
Also, gcc is also a package to be there, right? It is needed for a common set of libraries. 
I'm working with a very basic image where gcc is not installed by default.
