### PR TITLE
Added gcc as a dependency of PipRole (centos)

### DIFF
--- a/provy/more/centos/package/pip.py
+++ b/provy/more/centos/package/pip.py
@@ -48,6 +48,7 @@ class PipRole(Role):
             role.ensure_up_to_date()
             role.ensure_package_installed('python-setuptools')
             role.ensure_package_installed('python-devel')
+            role.ensure_package_installed('gcc')
         self.execute("easy_install pip", sudo=True, stdout=False)
 
     def is_package_installed(self, package_name, version=None):


### PR DESCRIPTION
As I said before. I'm working with a very basic image that doesn't come with gcc. 
Since it is used for a lot of C based modules, I think it is good to be checked.
