### PR TITLE
some fix for windows

### DIFF
--- a/provy/console.py
+++ b/provy/console.py
@@ -11,7 +11,7 @@
 import sys
 import os
 import re
-from os.path import exists, abspath, splitext
+from os.path import exists, abspath, splitext, basename
 from optparse import OptionParser
 
 from provy.core import run
@@ -53,7 +53,7 @@ def __get_provy_file_path(provyfile_name):
     path = abspath(provyfile_name)
     if not exists(path):
         return None
-    return splitext(path.replace(abspath('.'), '').lstrip('/').rstrip('/'))[0]
+    return splitext(basename(path))[0]
 
 
 def main():

--- a/provy/more/debian/monitoring/supervisor.py
+++ b/provy/more/debian/monitoring/supervisor.py
@@ -135,7 +135,7 @@ class SupervisorRole(Role):
         </pre>
         '''
 
-        options = {'config_file': join(config_file_path, 'supervisord.conf')}
+        options = {'config_file': '/'.join((config_file_path, 'supervisord.conf'))}
         result = self.update_file('supervisord.init.template', '/etc/init.d/supervisord', owner=self.context['owner'], options=options, sudo=True)
 
         if result:
@@ -211,7 +211,7 @@ class SupervisorRole(Role):
 
         self.context[CONFIG_KEY] = {
             'config_file_directory': config_file_directory,
-            'log_file': join(log_folder, 'supervisord.log'),
+            'log_file': '/'.join((log_folder, 'supervisord.log')),
             'log_file_max_mb': log_file_max_mb,
             'log_file_backups': log_file_backups,
             'log_level': log_level,
@@ -264,7 +264,7 @@ class SupervisorRole(Role):
 
             config = self.context[CONFIG_KEY]
 
-            conf_path = join(config['config_file_directory'], 'supervisord.conf')
+            conf_path = '/'.join((config['config_file_directory'], 'supervisord.conf'))
             options = config
 
             if PROGRAMS_KEY in self.context:

--- a/provy/more/debian/package/virtualenv.py
+++ b/provy/more/debian/package/virtualenv.py
@@ -69,7 +69,7 @@ class VirtualenvRole(Role):
                     self.env_dir('fancylib')
         </pre>
         '''
-        return os.path.join(self.base_directory, env_name)
+        return '/'.join((self.base_directory, env_name))
 
     @contextmanager
     def __call__(self, env_name, system_site_packages=False):


### PR DESCRIPTION
Replace path.join by '/'.join in the debian subfolder, since it is guaranteed to be linux paths. Otherwise, it doesn't work on windows (issues with antislash and backslash).
