### PR TITLE
Change in user role, actually bugfix.

### DIFF
--- a/provy/more/debian/users/user.py
+++ b/provy/more/debian/users/user.py
@@ -199,13 +199,3 @@ class UserRole(Role):
             self.execute('echo "%s:%s" | chpasswd' % (username, identified_by), stdout=False, sudo=True)
 
         self.context['owner'] = username
-
-
-def CreateUser(*largs, **kwargs):
-    """
-        Creates a role that creates a user on remote server.
-    """
-    class TempUserRole(UserRole):
-        def provision(self):
-            self.ensure_user(*largs, **kwargs)
-    return TempUserRole


### PR DESCRIPTION
On one of systems I provisioned usernames ened up with \r appended to them, this is because lines were split on newlines, so user foo would be wisible on python side as 'foo\r'. 

In new version lines are splitted over whitespace, which may be better.
