### PR TITLE
Bugfix for ensure line

### DIFF
--- a/provy/core/roles.py
+++ b/provy/core/roles.py
@@ -1208,7 +1208,7 @@ class Role(object):
             remote_file = self.create_remote_temp_file()
             self.put_file(StringIO(line), remote_file, bool(sudo or owner), stdout=False)
 
-            self.execute('cat "%s" >> %s' % (remote_file, file_path), stdout=False, sudo=sudo, user=owner)
+            self.execute('cat {line} >> {target} && echo >> {target}'.format(line=remote_file, target=file_path), stdout=False, sudo=sudo, user=owner)
             self.log('Line "%s" not found in %s. Adding it.' % (line, file_path))
 
     def using(self, role):

--- a/tests/unit/core/test_roles.py
+++ b/tests/unit/core/test_roles.py
@@ -136,7 +136,7 @@ class RoleTest(ProvyTestCase):
             has_line.return_value = False
             self.role.ensure_line(LINE_CONTENTS, "/some/file")
             put_file.assert_called_with(FileContentMatcher(self, LINE_CONTENTS), REMOTE_TMP_FILE, False, stdout=False)
-            execute.assert_called_with('cat "{}" >> /some/file'.format(REMOTE_TMP_FILE), stdout=False, sudo=False, user=None)
+            execute.assert_called_with('cat {} >> /some/file && echo >> /some/file'.format(REMOTE_TMP_FILE), stdout=False, sudo=False, user=None)
 
     @istest
     def inserts_line_if_it_doesnt_exist_yet_with_sudo(self):
@@ -149,7 +149,7 @@ class RoleTest(ProvyTestCase):
             has_line.return_value = False
             self.role.ensure_line(LINE_CONTENTS, "/some/file", sudo=True)
             put_file.assert_called_with(FileContentMatcher(self, LINE_CONTENTS), REMOTE_TMP_FILE, True, stdout=False)
-            execute.assert_called_with('cat "{}" >> /some/file'.format(REMOTE_TMP_FILE), stdout=False, sudo=True, user=None)
+            execute.assert_called_with('cat {} >> /some/file && echo >> /some/file'.format(REMOTE_TMP_FILE), stdout=False, sudo=True, user=None)
 
     @istest
     def inserts_line_if_it_doesnt_exist_yet_with_user(self):
@@ -162,7 +162,7 @@ class RoleTest(ProvyTestCase):
             has_line.return_value = False
             self.role.ensure_line(LINE_CONTENTS, "/some/file", owner="foo")
             put_file.assert_called_with(FileContentMatcher(self, LINE_CONTENTS), REMOTE_TMP_FILE, True, stdout=False)
-            execute.assert_called_with('cat "{}" >> /some/file'.format(REMOTE_TMP_FILE), stdout=False, sudo=False, user="foo")
+            execute.assert_called_with('cat {} >> /some/file && echo >> /some/file'.format(REMOTE_TMP_FILE), stdout=False, sudo=False, user="foo")
 
     @istest
     def registers_a_template_loader(self):


### PR DESCRIPTION
Well there is a regression in `ensure_line` previouisly new line was appended by `echo "line contents" >> /file/name`  I omitted the fact that `cat` does not append newline at the end of appended line. 

Fixed it in following commit. 
