### PR TITLE
Fix for has_line

### DIFF
--- a/provy/core/roles.py
+++ b/provy/core/roles.py
@@ -4,7 +4,7 @@
 '''
 Module responsible for the base Role and its operations.
 '''
-
+import re
 import codecs
 from contextlib import contextmanager
 import os
@@ -1176,8 +1176,10 @@ class Role(object):
 
         contents = self.read_remote_file(file_path).split('\n')
 
+        stripped_line = re.sub("\s+", '', line)
+
         for current_line in contents:
-            if line.replace(' ', '') == current_line.replace(' ', ''):
+            if stripped_line == re.sub("\s+", '', current_line):
                 return True
         return False
 

--- a/tests/unit/core/test_roles.py
+++ b/tests/unit/core/test_roles.py
@@ -914,6 +914,21 @@ class RoleTest(ProvyTestCase):
             self.role.read_remote_file.assert_called_with(file_path)
 
     @istest
+    def checks_that_a_file_has_a_certain_line_metachars(self):
+        content = "some content\r\n127.0.0.1    localhost\r\nsome other content"
+        file_path = '/some/path'
+        line = '127.0.0.1 localhost'
+
+        with self.mock_role_method('remote_exists'), self.mock_role_method('read_remote_file'):
+            self.role.remote_exists.return_value = True
+            self.role.read_remote_file.return_value = content
+
+            self.assertTrue(self.role.has_line(line, file_path))
+
+            self.role.remote_exists.assert_called_with(file_path)
+            self.role.read_remote_file.assert_called_with(file_path)
+
+    @istest
     def checks_that_a_file_doesnt_have_a_certain_line(self):
         content = """
         some content


### PR DESCRIPTION
If file `foo` has following content

```
  foo bar\r\n 
```

then `has_line` wouldnt find `foo bar` in contents since there would be comparision: 

```
 `foo bar\n` == `foo bar`
```

I have hanged has_line to strip all whitespace from line using regex `\s+` (previously only spaces were stripped). 
