### PR TITLE
fix tests on osx

### DIFF
--- a/tests/unit/core/test_roles.py
+++ b/tests/unit/core/test_roles.py
@@ -698,6 +698,7 @@ class RoleTest(ProvyTestCase):
         temp_file = self.role.write_to_temp_file(content)
         try:
             self.assertEqual(os.path.dirname(temp_file), tempfile.gettempdir())
+            self.assertTrue(os.path.isfile(temp_file))
 
             with open(temp_file) as f:
                 saved_content = f.read().strip()
@@ -713,6 +714,7 @@ class RoleTest(ProvyTestCase):
 
         try:
             self.assertEqual(os.path.dirname(temp_file), tempfile.gettempdir())
+            self.assertTrue(os.path.isfile(temp_file))
 
             with open(temp_file) as f:
                 saved_content = f.read().decode('utf-8').strip()


### PR DESCRIPTION
minor fixes to make it possible to run the tests on osx. 
tmp paths contain + characters, breaking regex asserts and test dir starts with /var/tmp
