### PR TITLE
Upgrading PostgreSQL version in provisioning

### DIFF
--- a/provy/more/debian/database/postgresql.py
+++ b/provy/more/debian/database/postgresql.py
@@ -46,7 +46,7 @@ class PostgreSQLRole(BasePostgreSQLRole):
     def __get_version(self):
         distro = self.get_distro_info()
         if distro.distributor_id.lower() == 'ubuntu':
-            version = '9.1'
+            version = '9.2'
         else:
             version = '8.4'
         return version

--- a/tests/unit/more/debian/database/test_postgresql.py
+++ b/tests/unit/more/debian/database/test_postgresql.py
@@ -17,7 +17,7 @@ class PostgreSQLRoleTest(PostgreSQLRoleTestCase):
         with self.using_stub(AptitudeRole) as mock_aptitude, self.provisioning_to('ubuntu'):
             self.role.provision()
             install_calls = mock_aptitude.ensure_package_installed.mock_calls
-            self.assertEqual(install_calls, [call('postgresql'), call('postgresql-server-dev-9.1')])
+            self.assertEqual(install_calls, [call('postgresql'), call('postgresql-server-dev-9.2')])
 
     @istest
     def installs_necessary_packages_to_provision_to_debian(self):


### PR DESCRIPTION
Hello guys,

Another contribution, this time to the database.

I want to suggest to upgrade to **PostgreSQL 9.2**, bypassing the bug "SELECT CURRENT_TIMESTAMP". This bug gets to **shutdown the database server**, but it was corrected in later versions.

I know that maybe the 9.1 version is more stable, then I would open this thread if worthwhile.
