### PR TITLE
Fixing build failure: a incorrect method mocking

### DIFF
--- a/tests/unit/more/debian/messaging/test_rabbitmq.py
+++ b/tests/unit/more/debian/messaging/test_rabbitmq.py
@@ -75,7 +75,7 @@ class RabbitMqRoleTest(ProvyTestCase):
 
     @istest
     def warns_about_guest_user(self, **mocks):
-        with self.using_stub(AptitudeRole), self.mock_role_methods('is_process_running', 'user_exists', 'execute'), patch('provy.more.centos.messaging.rabbitmq.warn') as warn:
+        with self.using_stub(AptitudeRole), self.mock_role_methods('is_process_running', 'user_exists', 'execute'), patch('provy.more.debian.messaging.rabbitmq.warn') as warn:
             self.role.is_process_running.return_value = True
             self.role.user_exists.return_value = True
 


### PR DESCRIPTION
@diogobaeder An incorrect method mock caused the failure. I'd seen the flaws but had not found the error. Now I believe that will work.
