### PR TITLE
Make aptitude role faster

### DIFF
--- a/provy/more/debian/package/aptitude.py
+++ b/provy/more/debian/package/aptitude.py
@@ -51,7 +51,7 @@ class AptitudeRole(Role):
         '''
 
         if not self.is_package_installed('aptitude'):
-            self.execute('apt-get update')
+            self.execute('apt-get update', stdout=False, sudo=True)
             self.execute('apt-get install aptitude -y', stdout=False, sudo=True)
 
         self.ensure_package_installed('curl')

--- a/tests/unit/more/debian/package/test_aptitude.py
+++ b/tests/unit/more/debian/package/test_aptitude.py
@@ -131,10 +131,10 @@ class AptitudeRoleTest(ProvyTestCase):
             self.role.provision()
 
             self.role.is_package_installed.assert_called_once_with('aptitude')
-            self.role.execute.call_args_list == [
+            self.assertEqual(self.role.execute.call_args_list, [
                 call('apt-get update', stdout=False, sudo=True),
                 call('apt-get install aptitude -y', stdout=False, sudo=True),
-            ]
+            ])
             self.role.ensure_package_installed.assert_called_once_with('curl')
 
     @istest


### PR DESCRIPTION
Aptitude role always executed `ensure_up_to_date` which often takes some time, albeit often it is unnecessary. 

Now Aptitude role executed `ensure_up_to_date` only if it actyally installs some packages, in this case when provisioning server that has all packages installed this role works significantly faster. 

As a bonus I added a call to `apt-get update` before installing `aptitude` --- this should be done. 
