### PR TITLE
Added ability to specify return codes.

### DIFF
--- a/provy/core/errors.py
+++ b/provy/core/errors.py
@@ -1,6 +1,10 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 
 class ConfigurationError(RuntimeError):
     '''Raised when there's a configuration error in the provyfile.'''
+
+class CommandExecutionError(RuntimeError):
+    '''
+    Raised when local command has invalid exitcode
+    '''


### PR DESCRIPTION
When getting returncode other than 0 `fabric` raises `SystemExit` error by default, which is very unformtuate, since it is one exception you really shouldn't catch in Python. 

You can of course use `fabric.api.settings(warn_only=True`, but you have to know of its existence, which can be hard. And we force user to use api other than `provy` api. I added a small feature that allows user to specify return codes that are considered as succesfull execurion, and if process return other return code I raise sane `CommandExecutionError`). 

Let me know if any further changes are neccessary. 
