### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/using-roles.rst
+++ b/docs/source/using-roles.rst
@@ -17,4 +17,4 @@ If you just want to provision another role in your role, you can use::
         def provision(self):
             self.provision_role(TornadoRole)
 
-The *provision_role* method does exactly the same as the *using* method, except it does not enter a with block. This should be used when you don't wnat to call anything in the role, instead just have it provisioned.
+The *provision_role* method does exactly the same as the *using* method, except it does not enter a with block. This should be used when you don't want to call anything in the role, instead just have it provisioned.

--- a/provy/core/roles.py
+++ b/provy/core/roles.py
@@ -364,7 +364,7 @@ class Role(object):
 
         :param str path: Path to list on the remote side.
 
-        :return: Remote directory lisitng.
+        :return: Remote directory listing.
 
         :rtype: list
         """

--- a/provy/more/debian/security/apparmor.py
+++ b/provy/more/debian/security/apparmor.py
@@ -116,7 +116,7 @@ class AppArmorRole(Role):
 
     def audit(self, *executables):
         '''
-        Puts the executables to audit mode - the policies are enforced, and all actions (legal and ilegal ones) will be logged -.
+        Puts the executables to audit mode - the policies are enforced, and all actions (legal and illegal ones) will be logged -.
 
         :param executables: The executables to change.
         :type executables: positional arguments of :class:`str`

--- a/provy/more/debian/users/passwd_utils.py
+++ b/provy/more/debian/users/passwd_utils.py
@@ -25,7 +25,7 @@ def random_salt_function(salt_len=12):
 
 def hash_password_function(password, salt=None, magic="6"):
     """
-    Hashes password using `crypt` function on local machine (which is not harmfull,
+    Hashes password using `crypt` function on local machine (which is not harmful,
     since these hashes are well-specified.
 
     :param password: Plaintext password to be hashed.

--- a/provy/more/debian/users/user.py
+++ b/provy/more/debian/users/user.py
@@ -155,7 +155,7 @@ class UserRole(Role):
         :param is_admin: If set to :data:`True` the user is added to the 'admin' (or 'sudo' if provisioning to Ubuntu) user group as well. Defaults to :data:`False`.
         :type is_admin: :class:`bool`
         :param password_encrypted:
-            If set to :data:`True` password is considered to be in ecrypted form
+            If set to :data:`True` password is considered to be in encrypted form
             (as found in /etc/shadow). To generate encrypted form of password you
             may use :func:`provy.more.debian.users.passwd_utils.hash_password_function`.
             defaults to :data:`False`


### PR DESCRIPTION
There are small typos in:
- docs/source/using-roles.rst
- provy/core/roles.py
- provy/more/debian/security/apparmor.py
- provy/more/debian/users/passwd_utils.py
- provy/more/debian/users/user.py

Fixes:
- Should read `want` rather than `wnat`.
- Should read `listing` rather than `lisitng`.
- Should read `illegal` rather than `ilegal`.
- Should read `harmful` rather than `harmfull`.
- Should read `encrypted` rather than `ecrypted`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md